### PR TITLE
Working tests on Windows

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,13 +1,11 @@
 {
-  "extends": "standard",
-  "extends": "seneca",
+  "extends": ["seneca"],
   "rules": {
     "no-labels": 0,
     "no-multiple-empty-lines": 0,
     "space-in-parens": 0,
-    no-return-assign: 0,
-    yoda: 0,
-    padded-blocks: 0
-  },
-
+    "no-return-assign": 0,
+    "yoda": 0,
+    "padded-blocks": 0
+  }
 }

--- a/package.json
+++ b/package.json
@@ -28,13 +28,13 @@
     "jsonic": "0.2.2",
     "lodash": "4.5.0",
     "nid": "0.3.2",
-    "seneca-transport": "https://github.com/feugy/seneca-transport.git",
+    "seneca-transport": "https://github.com/feugy/seneca-transport/archive/master.tar.gz",
     "sneeze": "0.3.4"
   },
   "devDependencies": {
     "docco": "0.7.0",
     "eslint": "2.3.0",
-    "eslint-config-seneca": "https://github.com/feugy/eslint-config-seneca.git",
+    "eslint-config-seneca": "https://github.com/feugy/eslint-config-seneca/archive/master.tar.gz",
     "eslint-plugin-standard": "1.3.2",
     "lab": "10.2.0",
     "seneca": "senecajs/seneca",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "Richard Rodger (http://richardrodger.com)"
   ],
   "scripts": {
-    "test": "lab test/*.test.js -r console -t 80 -v",
+    "test": "lab test --pattern \\.test -r console -t 80 -v",
     "annotate": "docco mesh.js -o doc"
   },
   "repository": {
@@ -32,9 +32,10 @@
   },
   "devDependencies": {
     "docco": "0.7.0",
+    "eslint": "2.3.0",
     "eslint-config-seneca": "1.1.1",
-    "eslint-plugin-standard": "1.3.1",
-    "lab": "6.2.0",
+    "eslint-plugin-standard": "1.3.2",
+    "lab": "10.2.0",
     "seneca": "senecajs/seneca",
     "seneca-balance-client": "rjrodger/seneca-balance-client"
   },

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "eslint": "2.3.0",
     "eslint-config-seneca": "https://github.com/feugy/eslint-config-seneca/archive/master.tar.gz",
     "eslint-plugin-standard": "1.3.2",
-    "lab": "10.2.0",
+    "lab": "6.2.0",
     "seneca": "senecajs/seneca",
     "seneca-balance-client": "rjrodger/seneca-balance-client"
   },

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "jsonic": "0.2.2",
     "lodash": "4.5.0",
     "nid": "0.3.2",
+    "seneca-transport": "github:feugy/seneca-transport",
     "sneeze": "0.3.4"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -28,13 +28,13 @@
     "jsonic": "0.2.2",
     "lodash": "4.5.0",
     "nid": "0.3.2",
-    "seneca-transport": "github:feugy/seneca-transport",
+    "seneca-transport": "https://github.com/feugy/seneca-transport.git",
     "sneeze": "0.3.4"
   },
   "devDependencies": {
     "docco": "0.7.0",
     "eslint": "2.3.0",
-    "eslint-config-seneca": "1.1.1",
+    "eslint-config-seneca": "https://github.com/feugy/eslint-config-seneca.git",
     "eslint-plugin-standard": "1.3.2",
     "lab": "10.2.0",
     "seneca": "senecajs/seneca",

--- a/test/base.js
+++ b/test/base.js
@@ -1,5 +1,5 @@
 // To run:
 // $ node base.js
 
-require('seneca')({tag:'b0'}).use('..',{isbase:true, sneeze:{silent:false}})
+require('seneca')({tag: 'b0'}).use('..', {isbase: true, sneeze: {silent: false}})
 

--- a/test/mesh.test.js
+++ b/test/mesh.test.js
@@ -6,7 +6,6 @@
 'use strict'
 
 var Assert = require('assert')
-var Util = require('util')
 
 var Lab = require('lab')
 var Seneca = require('seneca')
@@ -18,44 +17,47 @@ var it = lab.it
 
 describe('#mesh', function () {
 
-  it('base', {timeout:5555, parallel:false}, function (done) {
+  it('base', {timeout: 5555, parallel: false}, function (done) {
     var b0a
 
-    b0a = 
-      Seneca({tag:'b0a', log:'test', debug:{short_logs:true}})
+    b0a =
+      Seneca({tag: 'b0a', log: 'test', debug: {short_logs: true}})
       .error(done)
-      .use('..',{isbase:true})
+      .use('..', {isbase: true})
       .ready( function () {
-        this.close(setTimeout.bind(this,done,555))
+        this.close(setTimeout.bind(this, done, 555))
       })
   })
 
-  it('single', {parallel:false, timeout:5555}, function (done) {
+  it('single', {parallel: false, timeout: 5555}, function (done) {
     var b0b, s0b
 
-    b0b = 
-      Seneca({tag:'b0b', log:'silent', debug:{short_logs:true}})
+    b0b =
+      Seneca({tag: 'b0b', log: 'silent', debug: {short_logs: true}})
       .error(done)
-      .use('..',{isbase:true})
+      .use('..', {isbase: true})
 
-    s0b = 
-      Seneca({tag:'s0b', log:'silent', debug:{short_logs:true}})
+    s0b =
+      Seneca({tag: 's0b', log: 'silent', debug: {short_logs: true}})
       .error(done)
-      .add('a:1',function(msg){this.good({x:msg.i})})
+      .add('a:1', function (msg) { this.good({x: msg.i}) })
 
-    b0b.ready( function() {
-      s0b.use('..',{pin:'a:1'}).ready( function() {
+    b0b.ready( function () {
+      s0b.use('..', {pin: 'a:1'}).ready( function () {
+        s0b.act('role:mesh,get:members', function (err, list) {
+          Assert.ifError(err)
+          // since s0b is the only members, it's not included in the list
+          Assert.equal(0, list.length)
 
-        s0b.act('role:mesh,get:members',function (err, list) {
-          Assert.equal(1,list.length)
+          b0b.act('a:1,i:0', function (err, out) {
+            Assert.ifError(err)
+            Assert.equal(0, out.x)
 
-          b0b.act('a:1,i:0',function(err,out){
-            Assert.equal(0,out.x)
-          
-            b0b.act('a:1,i:1',function(err,out){
-              Assert.equal(1,out.x)
-          
-              s0b.close(b0b.close.bind(b0b,setTimeout.bind(this,done,555)))
+            b0b.act('a:1,i:1', function (err, out) {
+              Assert.ifError(err)
+              Assert.equal(1, out.x)
+
+              s0b.close(b0b.close.bind(b0b, setTimeout(function() {done()}, 555)))
             })
           })
         })
@@ -63,128 +65,140 @@ describe('#mesh', function () {
     })
   })
 
-  it('happy', {parallel:false}, function (done) {
+  it('happy', {parallel: false, timeout: 5000}, function (done) {
     var b0, s0, s1, c0
 
-    b0 = 
-      Seneca({tag:'b0', log:'test'})
+    b0 =
+      Seneca({tag: 'b0', log: 'test', debug: {short_logs: true}})
       .error(done)
-      .use('..',{isbase:true})
+      .use('..', {isbase: true})
       .ready( function () {
 
-        s0 = 
-          Seneca({tag:'s0', log:'test'})
+        s0 =
+          Seneca({tag: 's0', log: 'test', debug: {short_logs: true}})
           .error(done)
-          .use('..',{pin:'a:1'})
-          .add('a:1',function(){this.good({x:0})})
+          .use('..', {pin: 'a:1'})
+          .add('a:1', function () { this.good({x: 0}) })
           .ready( function () {
 
-            s1 = 
-              Seneca({tag:'s1', log:'test'})
+            s1 =
+              Seneca({tag: 's1', log: 'test', debug: {short_logs: true}})
               .error(done)
-              .use('..',{pins:'a:1'})
-              .add('a:1',function(){this.good({x:1})})
+              .use('..', {pins: 'a:1'})
+              .add('a:1', function () { this.good({x: 1}) })
               .ready( function () {
 
-                c0 = 
-                  Seneca({tag:'c0', log:'test'})
+                c0 =
+                  Seneca({tag: 'c0', log: 'test', debug: {short_logs: true}})
                   .error(done)
-                  .use('..',{})
-                  .ready( function () {
+                  .use('..')
+                  .ready(setTimeout.bind(null, process, 222))
+              }) }) })
 
-                      c0.act('a:1,s:0',function(e,o){
-                        //console.log(0,e,o)
-                        Assert.equal(0,o.x)
+    function process () {
+      c0.act('a:1,s:0', function (e, o) {
+        Assert.ifError(e)
+        Assert.equal(0, o.x)
 
-                        c0.act('a:1,s:1',function(e,o){
-                          //console.log(0,e,o)
-                          Assert.equal(1,o.x)
+        c0.act('a:1,s:1', function (e, o) {
+          Assert.ifError(e)
+          Assert.equal(1, o.x)
 
-                          c0.act('a:1,s:2',function(e,o){
-                            //console.log(0,e,o)
-                            Assert.equal(0,o.x)
+          c0.act('a:1,s:2', function (e, o) {
+            Assert.ifError(e)
+            Assert.equal(0, o.x)
 
-                            b0.act('role:mesh,get:members',function(e,o){
-                              Assert.equal(3,o.length)
+            b0.act('role:mesh,get:members', function (e, o) {
+              Assert.ifError(e)
+              Assert.equal(3, o.length)
 
-                              s0.close( function() {
-                              
-                                setTimeout( function() {
-                                  c0.act('a:1,s:3',function(e,o){
-                                    //console.log(0,e,o)
-                                    Assert.equal(1,o.x)
+              s0.close( function () {
 
-                                    c0.act('a:1,s:4',function(e,o){
-                                      //console.log(0,e,o)
-                                      Assert.equal(1,o.x)
-                              
-                                      c0.close( function(){
-                                        s1.close( function(){
-                                          b0.close( function(){
-                                            done()
-                                          })
-                                        })
-                                      })
-                                    })
-                                  })
-                                },555)
-                              })
-                            })
+                setTimeout( function () {
+                  c0.act('a:1,s:3', function (e, o) {
+                    Assert.equal(1, o.x)
+
+                    c0.act('a:1,s:4', function (e, o) {
+                      Assert.equal(1, o.x)
+
+                      c0.close( function () {
+                        s1.close( function () {
+                          b0.close( function () {
+                            done()
                           })
                         })
                       })
+                    })
                   })
+                }, 555)
               })
+            })
           })
+        })
       })
+    }
   })
 
-
-  it('many-actors', {parallel:false, timeout:9999}, function (done) {
+  it('many-actors', {parallel: false, timeout: 9999}, function (done) {
     var b0, s0, s1, s2, c0, c1
+    var members = ['s0', 's1', 's2', 'c0', 'c1']
 
-    b0 = Seneca({tag:'b0', log:'test', debug: {short_logs: true}})
+    b0 = Seneca({tag: 'b0', log: 'test', debug: {short_logs: true}})
       .error(done)
 
-    s0 = Seneca({tag:'s0', log:'test', debug: {short_logs: true}})
+    s0 = Seneca({tag: 's0', log: 'test', debug: {short_logs: true}})
       .error(done)
-      .add('a:1',function(m){this.good({x:m.x+1})})
+      .add('a:1', function (m) { this.good({x: m.x + 1}) })
 
-    s1 = Seneca({tag:'s1', log:'test', debug: {short_logs: true}})
+    s1 = Seneca({tag: 's1', log: 'test', debug: {short_logs: true}})
       .error(done)
-      .add('a:1',function(m){this.good({x:m.x+2})})
+      .add('a:1', function (m) { this.good({x: m.x + 2}) })
 
-    s2 = Seneca({tag:'s2', log:'test', debug: {short_logs: true}})
+    s2 = Seneca({tag: 's2', log: 'test', debug: {short_logs: true}})
       .error(done)
-      .add('a:1',function(m){this.good({x:m.x+3})})
+      .add('a:1', function (m) { this.good({x: m.x + 3}) })
 
-    c0 = Seneca({tag:'c0', log:'test', debug: {short_logs: true}})
-      .error(done)
-
-    c1 = Seneca({tag:'c1', log:'test', debug: {short_logs: true}})
+    c0 = Seneca({tag: 'c0', log: 'test', debug: {short_logs: true}})
       .error(done)
 
-    
-    b0.use('..',{isbase:true}).ready( function() {
-      s0.use('..',{pin:'a:1',model:'actor'}).ready( function() {
-        s1.use('..',{pin:'a:1',model:'actor'}).ready( function() {
-          s2.use('..',{pin:'a:1',model:'actor'}).ready( function() {
-            c0.use('..').ready( function() {
-              c1.use('..').ready( setTimeout.bind(null,do_topology,222) ) })})})})})
+    c1 = Seneca({tag: 'c1', log: 'test', debug: {short_logs: true}})
+      .error(done)
 
-    function do_topology() {
-      c0.act('role:mesh,get:members', function (err,list) {
-        Assert.equal(5, list.length)
 
-        c1.act('role:mesh,get:members', function (err,list) {
-          Assert.equal(5, list.length)
+    b0.use('..', {isbase: true}).ready( function () {
+      s0.use('..', {pin: 'a:1', model: 'actor'}).ready( function () {
+        s1.use('..', {pin: 'a:1', model: 'actor'}).ready( function () {
+          s2.use('..', {pin: 'a:1', model: 'actor'}).ready( function () {
+            c0.use('..').ready( function () {
+              c1.use('..').ready( setTimeout.bind(null, do_topology, 222) )
+            }) }) }) }) })
 
-          c0.act('role:transport,type:balance,get:target-map,pg:"a:1"', function (err,c0map) {
+    function assertMemberList (expected, actual) {
+      expected.forEach(function (name) {
+        Assert.ok(actual.some(function (member) {
+          return member.instance.indexOf('/' + name) !== -1
+        }), name + ' not found in the member list !')
+      })
+      Assert.equal(expected.length, actual.length)
+    }
+
+    function do_topology () {
+      c0.act('role:mesh,get:members', function (err, list) {
+        Assert.ifError(err)
+        // all members are visible except c0 itslef
+        assertMemberList(members.slice(0, 3).concat(members.slice(4)), list)
+
+        c1.act('role:mesh,get:members', function (err, list) {
+          Assert.ifError(err)
+          // all members are visible except c1 itslef
+          assertMemberList(members.slice(0, 4), list)
+
+          c0.act('role:transport,type:balance,get:target-map,pg:"a:1"', function (err, c0map) {
             Assert.equal(3, c0map['a:1'].targets.length)
 
-            c1.act('role:transport,type:balance,get:target-map,pg:"a:1"', function (err,c1map) {
+            c1.act('role:transport,type:balance,get:target-map,pg:"a:1"', function (err, c1map) {
               Assert.equal(3, c1map['a:1'].targets.length)
-            
+
               do_actors(c0map, c1map)
             })
           })
@@ -192,188 +206,185 @@ describe('#mesh', function () {
       })
     }
 
-    function do_actors(c0map, c1map) {
-      var i = 0
-      //console.log(i++,'c0',c0map['a:1'].index,c0map.x,'c1',c1map['a:1'].index,c1map.x)
+    function do_actors (c0map, c1map) {
+      c0.act('a:1,x:0', function (e, o) {
+        Assert.equal(1, o.x)
 
-      c0.act('a:1,x:0', function(e,o){
-        //console.log(i++,'c0',c0map['a:1'].index,'c1',c1map['a:1'].index)
-        Assert.equal(1,o.x)
+        c1.act('a:1,x:0', function (e, o) {
+          Assert.equal(1, o.x)
 
-        c1.act('a:1,x:0', function(e,o){
-          //console.log(i++,'c0',c0map['a:1'].index,'c1',c1map['a:1'].index)
-          Assert.equal(1,o.x)
+          c0.act('a:1,x:0', function (e, o) {
+            Assert.equal(2, o.x)
 
-          c0.act('a:1,x:0', function(e,o){
-            Assert.equal(2,o.x)
+            c1.act('a:1,x:0', function (e, o) {
+              Assert.equal(2, o.x)
 
-            c1.act('a:1,x:0', function(e,o){
-              Assert.equal(2,o.x)
+              c0.act('a:1,x:0', function (e, o) {
+                Assert.equal(3, o.x)
 
-              c0.act('a:1,x:0', function(e,o){
-                Assert.equal(3,o.x)
+                c1.act('a:1,x:0', function (e, o) {
+                  Assert.equal(3, o.x)
 
-                c1.act('a:1,x:0', function(e,o){
-                  Assert.equal(3,o.x)
+                  c0.act('a:1,x:0', function (e, o) {
+                    Assert.equal(1, o.x)
 
-                  c0.act('a:1,x:0', function(e,o){
-                    Assert.equal(1,o.x)
+                    c1.act('a:1,x:0', function (e, o) {
+                      Assert.equal(1, o.x)
 
-                    c1.act('a:1,x:0', function(e,o){
-                      Assert.equal(1,o.x)
+                      c0.act('a:1,x:0', function (e, o) {
+                        Assert.equal(2, o.x)
 
-                      c0.act('a:1,x:0', function(e,o){
-                        Assert.equal(2,o.x)
+                        c1.act('a:1,x:0', function (e, o) {
+                          Assert.equal(2, o.x)
 
-                        c1.act('a:1,x:0', function(e,o){
-                          Assert.equal(2,o.x)
+                          c0.act('a:1,x:0', function (e, o) {
+                            Assert.equal(3, o.x)
 
-                          c0.act('a:1,x:0', function(e,o){
-                            Assert.equal(3,o.x)
+                            c1.act('a:1,x:0', function (e, o) {
+                              Assert.equal(3, o.x)
 
-                            c1.act('a:1,x:0', function(e,o){
-                              Assert.equal(3,o.x)
-
-                              s1.close( setTimeout.bind(this,do_s1_down,555) )
-                            })})})
-                      })})})
-                })})})
-          })})})
+                              s1.close( setTimeout.bind(this, do_s1_down, 555) )
+                            }) }) })
+                      }) }) })
+                }) }) })
+          }) }) })
     }
 
-    function do_s1_down() {
-      c0.act('a:1,x:0', function(e,o){
-        Assert.equal(1,o.x)
+    function do_s1_down () {
+      c0.act('a:1,x:0', function (e, o) {
+        Assert.equal(1, o.x)
 
-        c1.act('a:1,x:0', function(e,o){
-          Assert.equal(1,o.x)
+        c1.act('a:1,x:0', function (e, o) {
+          Assert.equal(1, o.x)
 
-          c0.act('a:1,x:0', function(e,o){
-            Assert.equal(3,o.x)
+          c0.act('a:1,x:0', function (e, o) {
+            Assert.equal(3, o.x)
 
-            c1.act('a:1,x:0', function(e,o){
-              Assert.equal(3,o.x)
+            c1.act('a:1,x:0', function (e, o) {
+              Assert.equal(3, o.x)
 
-              c0.act('a:1,x:0', function(e,o){
-                Assert.equal(1,o.x)
+              c0.act('a:1,x:0', function (e, o) {
+                Assert.equal(1, o.x)
 
-                c1.act('a:1,x:0', function(e,o){
-                  Assert.equal(1,o.x)
+                c1.act('a:1,x:0', function (e, o) {
+                  Assert.equal(1, o.x)
 
-                  c0.act('a:1,x:0', function(e,o){
-                    Assert.equal(3,o.x)
+                  c0.act('a:1,x:0', function (e, o) {
+                    Assert.equal(3, o.x)
 
-                    c1.act('a:1,x:0', function(e,o){
-                      Assert.equal(3,o.x)
+                    c1.act('a:1,x:0', function (e, o) {
+                      Assert.equal(3, o.x)
 
-                      c0.act('a:1,x:0', function(e,o){
-                        Assert.equal(1,o.x)
+                      c0.act('a:1,x:0', function (e, o) {
+                        Assert.equal(1, o.x)
 
-                        c1.act('a:1,x:0', function(e,o){
-                          Assert.equal(1,o.x)
+                        c1.act('a:1,x:0', function (e, o) {
+                          Assert.equal(1, o.x)
 
-                          c0.act('a:1,x:0', function(e,o){
-                            Assert.equal(3,o.x)
+                          c0.act('a:1,x:0', function (e, o) {
+                            Assert.equal(3, o.x)
 
-                            c1.act('a:1,x:0', function(e,o){
-                              Assert.equal(3,o.x)
+                            c1.act('a:1,x:0', function (e, o) {
+                              Assert.equal(3, o.x)
 
                               close()
-                            })})})
-                      })})})
-                })})})
-          })})})
+                            }) }) })
+                      }) }) })
+                }) }) })
+          }) }) })
     }
 
-      
-    function close() {
+
+    function close () {
       c1.close(
         c0.close.bind(
-          c0,s2.close.bind(
-            s2,s0.close.bind(
-                s0,b0.close.bind(
-                  b0,setTimeout.bind(this,done,555))))))
+          c0, s2.close.bind(
+            s2, s0.close.bind(
+                s0, b0.close.bind(
+                  b0, setTimeout.bind(this, done, 555))))))
 
     }
 
   })
 
 
-  it('observe-consume-basic', {parallel:false, timeout:9999}, function (done) {
+  it('observe-consume-basic', {parallel: false, timeout: 9999}, function (done) {
     var b0, s0, s1, c0
-    var s0x = 0, s1z = 0, s0y = [], s1y = []
+    var s0x = 0
+    var s1z = 0
+    var s0y = []
+    var s1y = []
 
-    b0 = Seneca({tag:'b0', log:'test'})
+    b0 = Seneca({tag: 'b0', log: 'test', debug: {short_logs: true}})
       .error(done)
 
-    s0 = Seneca({tag:'s0', log:'test'})
+    s0 = Seneca({tag: 's0', log: 'test', debug: {short_logs: true}})
       .error(done)
-      .add('a:1',function(m){this.good({x:m.x+(++s0x)})})
-      .add('b:1',function(m){s0y.push(m.y);this.good()})
+      .add('a:1', function (m) { this.good({x: m.x + (++s0x)}) })
+      .add('b:1', function (m) { s0y.push(m.y); this.good() })
 
-    s1 = Seneca({tag:'s1', log:'test'})
+    s1 = Seneca({tag: 's1', log: 'test', debug: {short_logs: true}})
       .error(done)
-      .add('b:1',function(m){s1y.push(m.y);this.good()})
-      .add('c:1',function(m){this.good({z:m.z+(++s1z)})})
+      .add('b:1', function (m) { s1y.push(m.y); this.good() })
+      .add('c:1', function (m) { this.good({z: m.z + (++s1z)}) })
 
-    c0 = Seneca({tag:'c0', log:'test'})
+    c0 = Seneca({tag: 'c0', log: 'test', debug: {short_logs: true}})
       .error(done)
 
 
-    
-    b0.use('..',{isbase:true}).ready( function() {
-      s0.use('..',{
-        listen:[
-          {pin:'a:1'},
-          {pin:'b:1',model:'publish'},
+
+    b0.use('..', {isbase: true}).ready( function () {
+      s0.use('..', {
+        listen: [
+          {pin: 'a:1'},
+          {pin: 'b:1', model: 'publish'}
         ]
-      }).ready( function() {
+      }).ready( function () {
+        s1.use('..', {
+          listen: [
+            {pin: 'c:1'},
+            {pin: 'b:1', model: 'publish'}
+          ]
+        }).ready( function () {
+          c0.use('..').ready(setTimeout.bind(null, do_abc, 222))
+        }) }) })
 
-          s1.use('..',{
-            listen:[
-              {pin:'c:1'},
-              {pin:'b:1',model:'publish'},
-            ]
-          }).ready( function() {
 
-              c0.use('..').ready( do_abc )})})})
+    function do_abc () {
+      c0.act('a:1,x:0', function (e, o) {
+        Assert.equal(1, o.x)
 
-
-    function do_abc() {
-      c0.act('a:1,x:0', function(e,o){
-        Assert.equal(1,o.x)
-
-        c0.act('a:1,x:0', function(e,o){
-          Assert.equal(2,o.x)
+        c0.act('a:1,x:0', function (e, o) {
+          Assert.equal(2, o.x)
 
           c0.act('b:1,y:0')
           c0.act('b:1,y:1')
           c0.act('b:1,y:2')
           c0.act('b:1,y:3')
 
-          setTimeout( function() {
-            Assert.deepEqual([0,1,2,3],s0y)
-            Assert.deepEqual([0,1,2,3],s1y)
+          setTimeout( function () {
+            Assert.deepEqual([0, 1, 2, 3], s0y)
+            Assert.deepEqual([0, 1, 2, 3], s1y)
 
-            c0.act('c:1,z:0', function(e,o){
-              Assert.equal(1,o.z)
+            c0.act('c:1,z:0', function (e, o) {
+              Assert.equal(1, o.z)
 
-              c0.act('c:1,z:0', function(e,o){
-                Assert.equal(2,o.z)
+              c0.act('c:1,z:0', function (e, o) {
+                Assert.equal(2, o.z)
 
                 close()
-              })})
-          },111)
-        })})
+              }) })
+          }, 111)
+        }) })
     }
 
-      
-    function close() {
+
+    function close () {
       c0.close(
         s1.close.bind(
-          s1,s0.close.bind(
-            s0,b0.close.bind(
-              b0,setTimeout.bind(this,done,555)))))
+          s1, s0.close.bind(
+            s0, b0.close.bind(
+              b0, setTimeout.bind(this, done, 555)))))
     }
   })
 })

--- a/test/service-bar.js
+++ b/test/service-bar.js
@@ -1,13 +1,13 @@
-require('seneca')({tag:'bar'})
+require('seneca')({tag: 'bar'})
   .add( 'bar:1', function (msg, done) {
-    done( null, {y:1,v:100+msg.v} )
+    done( null, {y: 1, v: 100 + msg.v} )
   })
-  .use('..', { pin:'bar:1', sneeze:{silent:false} })
+  .use('..', { pin: 'bar:1', sneeze: {silent: false} })
 
   .ready( function () {
     var seneca = this
 
-    setInterval( function() {
+    setInterval( function () {
       seneca.act('foo:1,v:1,default$:{}', console.log)
     }, 3000 )
   })

--- a/test/service-foo.js
+++ b/test/service-foo.js
@@ -1,13 +1,13 @@
-require('seneca')({tag:'foo'})
+require('seneca')({tag: 'foo'})
   .add( 'foo:1', function (msg, done) {
-    done( null, {x:1,v:100+msg.v} )
+    done( null, {x: 1, v: 100 + msg.v} )
   })
-  .use('..', { pin:'foo:1', sneeze:{silent:false} })
+  .use('..', { pin: 'foo:1', sneeze: {silent: false} })
 
   .ready( function () {
     var seneca = this
 
-    setInterval( function() {
+    setInterval( function () {
       seneca.act('bar:1,v:2,default$:{}', console.log)
     }, 3000 )
   })


### PR DESCRIPTION
I've encounter some issues while running mesh on Windows.
Basically, services can connect to mesh base, but actions are not routed to matching services.

This PR includes:
- the usage of a patched seneca-transport, that makes a proper use of default host (no 0.0.0.0)
- test expectations fixes.
- cosmetic eslint fixes and the usage of patched eslint-config-seneca, compliant with eslint 2+

But the main question remains: when using Seneca instances built without the `{debug: {short_logs: true}}` option, actions can't be routed. 
Why is the impact of this option on routing ?

Last remark: the last test `observe-consume-basic` is very sensitive to execution time. Sometimes it fails because actions are not executed in the expected order, and sometimes it works.