### PR TITLE
Add rejoin on base lost

### DIFF
--- a/mesh.js
+++ b/mesh.js
@@ -370,6 +370,7 @@ function mesh(options) {
 
                   // retry on error
                   sneeze.once('error', function() {
+                    sneeze.leave()
                     setTimeout(rejoin, 1111)
                   })
                   sneeze.join(instanceMeta)

--- a/mesh.js
+++ b/mesh.js
@@ -316,8 +316,12 @@ function mesh(options) {
           }
 
           function remove_client(meta, cleaning_up) {
+            var base_left = false
             if (closed) return
-            if (meta.config.pin[0] === 'base:true,role:mesh') --alive_bases
+            if (meta.config.pin[0] === 'base:true,role:mesh') {
+              base_left = true
+              --alive_bases
+            }
 
             // ignore myself
             if (client_instance.id === meta.instance) {
@@ -349,6 +353,7 @@ function mesh(options) {
 
             if (
               options.discover.rediscover &&
+              base_left === true &&
               alive_bases < 1 &&
               cleaning_up !== true
             ) {

--- a/mesh.js
+++ b/mesh.js
@@ -368,6 +368,10 @@ function mesh(options) {
 
                   sneeze_opts.bases = bases
 
+                  // retry on error
+                  sneeze.once('error', function() {
+                    setTimeout(rejoin, 1111)
+                  })
                   sneeze.join(instanceMeta)
                 })
               }

--- a/mesh.js
+++ b/mesh.js
@@ -20,13 +20,16 @@ module.exports = mesh
 var DEFAULT_HOST = (module.exports.DEFAULT_HOST = '127.0.0.1')
 var DEFAULT_PORT = (module.exports.DEFAULT_PORT = 39999)
 
-var intern = module.exports.intern = make_intern()
+var intern = (module.exports.intern = make_intern())
 
 var optioner = Optioner({
   pin: Joi.alternatives().try(Joi.string(), Joi.object()),
   pins: Joi.array(),
   host: Joi.string(),
-  port: Joi.number().integer().min(0).max(65535),
+  port: Joi.number()
+    .integer()
+    .min(0)
+    .max(65535),
   isbase: false,
 
   model: 'consume',
@@ -156,14 +159,17 @@ function mesh(options) {
           active: !!options.monitor
         }
 
-        sneeze_opts.tag = void 0 !== sneeze_opts.tag
-          ? sneeze_opts.tag
-          : void 0 !== tag
+        sneeze_opts.tag =
+          void 0 !== sneeze_opts.tag
+            ? sneeze_opts.tag
+            : void 0 !== tag
               ? null === tag ? null : 'seneca~' + tag
               : 'seneca~mesh'
 
-        seneca.add('role:transport,cmd:listen', 
-                   intern.make_transport_listen(options, join, listen, init_done))
+        seneca.add(
+          'role:transport,cmd:listen',
+          intern.make_transport_listen(options, join, listen, init_done)
+        )
 
         // call seneca.listen as a convenience
         // subsequent seneca.listen calls will still publish to network
@@ -177,11 +183,12 @@ function mesh(options) {
               listen_opts.host = rif(listen_opts.host.substring(1))
             }
 
-            listen_opts.port = null != listen_opts.port
-              ? listen_opts.port
-              : function() {
-                  return 50000 + Math.floor(10000 * Math.random())
-                }
+            listen_opts.port =
+              null != listen_opts.port
+                ? listen_opts.port
+                : function() {
+                    return 50000 + Math.floor(10000 * Math.random())
+                  }
 
             listen_opts.model = listen_opts.model || 'consume'
 
@@ -191,10 +198,9 @@ function mesh(options) {
           })
         }
 
-
         function join(instance, raw_config, done) {
           var client_instance = instance.root.delegate()
-          var config = seneca.util.clean(raw_config || {}, {proto:false})
+          var config = seneca.util.clean(raw_config || {}, { proto: false })
 
           if (!config.pin && !config.pins) {
             config.pin = 'null:true'
@@ -271,9 +277,8 @@ function mesh(options) {
               )
 
               var has_balance_client = !!balance_map[pin_config.pin]
-              var target_map = (balance_map[pin_config.pin] = balance_map[
-                pin_config.pin
-              ] || {})
+              var target_map = (balance_map[pin_config.pin] =
+                balance_map[pin_config.pin] || {})
 
               // this is a duplicate, so ignore
               if (target_map[pin_config.id]) {
@@ -289,7 +294,6 @@ function mesh(options) {
               }
 
               target_map[pin_config.id] = true
-
 
               if (!has_balance_client) {
                 // no balancer for this pin, so add one
@@ -342,10 +346,9 @@ function mesh(options) {
   })
 }
 
-
 function make_intern() {
   return {
-    make_transport_listen: function (options, join, listen, init_done) {
+    make_transport_listen: function(options, join, listen, init_done) {
       var listen_count = 0
       var last_mesh_listen_err = null
 
@@ -370,9 +373,9 @@ function make_intern() {
 
               // only finish mesh plugin init if all auto listens attempted
               if (listen.length === listen_count) {
-                setTimeout(function(){
+                setTimeout(function() {
                   init_done(last_mesh_listen_err)
-                },options.jointime)
+                }, options.jointime)
               }
             })
           } else {
@@ -426,7 +429,8 @@ function make_intern() {
         do {
           ++abI
         } while (
-          abI < addbases.length && !options.discover[addbases[abI]].active
+          abI < addbases.length &&
+          !options.discover[addbases[abI]].active
         )
 
         addbase = addbases[abI]
@@ -443,9 +447,8 @@ function make_intern() {
 
     addbase_funcmap: {
       defined: function(seneca, options, bases, next) {
-        var add = (options.sneeze || {}).bases ||
-              options.bases ||
-              options.remotes || []
+        var add =
+          (options.sneeze || {}).bases || options.bases || options.remotes || []
 
         add = add.filter(function(base) {
           return base && 0 < base.length
@@ -522,7 +525,7 @@ function make_intern() {
         var first = true
 
         var base_addr =
-              (options.host || DEFAULT_HOST) + ':' + (options.port || DEFAULT_PORT)
+          (options.host || DEFAULT_HOST) + ':' + (options.port || DEFAULT_PORT)
 
         if (options.isbase) {
           var ri = options.discover.registry.refresh_interval
@@ -551,8 +554,8 @@ function make_intern() {
 
               if (options.isbase) {
                 var prune_first =
-                      Math.random() <
-                      options.discover.registry.prune_first_probability
+                  Math.random() <
+                  options.discover.registry.prune_first_probability
 
                 if (prune_first || -1 === add.indexOf(base_addr)) {
                   add.push(base_addr)
@@ -560,7 +563,7 @@ function make_intern() {
 
                   if (
                     prune_first &&
-                      options.discover.registry.prune_bound < add.length
+                    options.discover.registry.prune_bound < add.length
                   ) {
                     add.shift()
                   }

--- a/package.json
+++ b/package.json
@@ -48,17 +48,17 @@
   },
   "devDependencies": {
     "chairo": "2.2.1",
+    "code": "4.1.x",
     "color": "0.11.3",
     "coveralls": "2.13.x",
     "docco": "0.7.x",
     "hapi": "15.0.2",
     "lab": "14.0.x",
-    "code": "4.1.x",
-    "seneca-repl": "1.0.x",
+    "prettier": "^1.10.2",
     "seneca": "plugin",
     "seneca-balance-client": "0.6.1",
     "seneca-consul-registry": "0.1.0",
-    "prettier": "1.4.x"
+    "seneca-repl": "1.0.x"
   },
   "files": [
     "README.md",

--- a/test/mesh.test.js
+++ b/test/mesh.test.js
@@ -5,7 +5,6 @@
 
 'use strict'
 
-
 var Assert = require('assert')
 var Util = require('util')
 
@@ -14,212 +13,223 @@ var Code = require('code')
 var Seneca = require('seneca')
 var Rif = require('rif')
 
-
-var lab = exports.lab = Lab.script()
+var lab = (exports.lab = Lab.script())
 var describe = lab.describe
 var it = lab.it
 var expect = Code.expect
-
 
 var Mesh = require('..')
 
 var intern = Mesh.intern
 
-
 var test_discover = {
   stop: true,
-  guess: {active: true},
-  multicast: {active: false},
-  registry: {active: false}
+  guess: { active: true },
+  multicast: { active: false },
+  registry: { active: false }
 }
 
+describe('#mesh', function() {
+  it('nextgen-single-with-base', { parallel: false, timeout: 5555 }, function(
+    fin
+  ) {
+    var b0 = Seneca({ tag: 'b0', legacy: { transport: false } })
+      .test(fin)
+      .use('..', { base: true, discover: test_discover })
 
-describe('#mesh', function () {
+    var s0 = Seneca({ tag: 's0', legacy: { transport: false } })
+      .test(fin)
+      .add('a:1', function(msg, reply) {
+        reply({ x: msg.x })
+      })
 
-  it('nextgen-single-with-base', {parallel: false, timeout: 5555}, function (fin) {
-    var b0 = Seneca({tag: 'b0', legacy: { transport: false }})
-        .test(fin)
-        .use('..', {base: true, discover: test_discover})
+    b0.ready(function() {
+      s0.use('..', { pin: 'a:1', discover: test_discover }).ready(function() {
+        b0.act('a:1,x:0', function(ignore, out) {
+          Assert.equal(0, out.x)
 
-    var s0 = Seneca({tag: 's0', legacy: { transport: false }})
-        .test(fin)
-        .add('a:1', function (msg, reply) { reply({x: msg.x}) })
+          b0.act('a:1,x:1', function(ignore, out) {
+            Assert.equal(1, out.x)
 
-    b0.ready(function () {
-      s0
-        .use('..', {pin: 'a:1', discover: test_discover})
-        .ready(function () {
-
-          b0.act('a:1,x:0', function (ignore, out) {
-            Assert.equal(0, out.x)
-
-            b0.act('a:1,x:1', function (ignore, out) {
-              Assert.equal(1, out.x)
-
-              s0.close(b0.close.bind(b0, setTimeout.bind(this, fin, 555)))
-            })
+            s0.close(b0.close.bind(b0, setTimeout.bind(this, fin, 555)))
           })
         })
+      })
     })
   })
 
-
-  it('intern.resolve_bases', function (done) {
+  it('intern.resolve_bases', function(done) {
     var rif = make_rif()
 
-    Assert.equal(
-      '',
-      '' + intern.resolve_bases())
-
-    Assert.equal(Mesh.DEFAULT_HOST + ':' + Mesh.DEFAULT_PORT +
-                 ',192.168.1.2:' + Mesh.DEFAULT_PORT,
-                 '' + intern.resolve_bases([':' + Mesh.DEFAULT_PORT],
-                                         {host: '192.168.1.2'}, rif))
+    Assert.equal('', '' + intern.resolve_bases())
 
     Assert.equal(
-      'foo:' + Mesh.DEFAULT_PORT + ',' +
-      'bar:' + Mesh.DEFAULT_PORT,
-      '' + intern.resolve_bases(['foo', 'bar'], null, rif))
+      Mesh.DEFAULT_HOST +
+        ':' +
+        Mesh.DEFAULT_PORT +
+        ',192.168.1.2:' +
+        Mesh.DEFAULT_PORT,
+      '' +
+        intern.resolve_bases(
+          [':' + Mesh.DEFAULT_PORT],
+          { host: '192.168.1.2' },
+          rif
+        )
+    )
+
+    Assert.equal(
+      'foo:' + Mesh.DEFAULT_PORT + ',' + 'bar:' + Mesh.DEFAULT_PORT,
+      '' + intern.resolve_bases(['foo', 'bar'], null, rif)
+    )
 
     Assert.equal(
       Mesh.DEFAULT_HOST + ':33333',
-      '' + intern.resolve_bases([':33333'], null, rif))
+      '' + intern.resolve_bases([':33333'], null, rif)
+    )
 
     Assert.equal(
       Mesh.DEFAULT_HOST + ':33333,' + 'zed:33333',
-      '' + intern.resolve_bases([':33333'], {host: 'zed'}, rif))
+      '' + intern.resolve_bases([':33333'], { host: 'zed' }, rif)
+    )
 
     Assert.equal(
       '127.0.0.1:' + Mesh.DEFAULT_PORT,
-      '' + intern.resolve_bases(['@lo'], null, rif))
+      '' + intern.resolve_bases(['@lo'], null, rif)
+    )
 
     done()
   })
 
+  it('intern.make_pin_config', function(done) {
+    var si = Seneca({ log: 'silent' })
 
-  it('intern.make_pin_config', function (done) {
-    var si = Seneca({log: 'silent'})
-
-    expect(intern.make_pin_config(
-      si, {identifier$: 'i0'}, 'a:1', {pin: 'a:1', x: 1})).to.equal({
-        id: 'pin:a:1,x:1~i0',
+    expect(
+      intern.make_pin_config(si, { identifier$: 'i0' }, 'a:1', {
         pin: 'a:1',
         x: 1
       })
-
-    expect(intern.make_pin_config(
-      si, {identifier$: 'i0'}, 'a:1', {pins: [{a: 1}, 'b:1'], x: 1})).to.equal({
-        id: 'pin:a:1,x:1~i0',
-        pin: 'a:1',
-        x: 1
-      })
-
-    done()
-  })
-
-
-  it('intern.resolve_pins', function (done) {
-    var si = Seneca({log: 'silent'})
-
-    expect(intern.resolve_pins(si, {pin: 'a:1'}))
-           .to.equal(['a:1'])
-
-    expect(intern.resolve_pins(si, {pin: {a: 1}}))
-           .to.equal(['a:1'])
-
-    expect(intern.resolve_pins(si, {pins: 'a:1'}))
-           .to.equal(['a:1'])
-
-    expect(intern.resolve_pins(si, {pins: {a: 1}}))
-           .to.equal(['a:1'])
-
-    expect(intern.resolve_pins(si, {pin: ['a:1']}))
-           .to.equal(['a:1'])
-
-    expect(intern.resolve_pins(si, {pin: [{a: 1}]}))
-           .to.equal(['a:1'])
-
-    expect(intern.resolve_pins(si, {pins: ['a:1']}))
-           .to.equal(['a:1'])
-
-    expect(intern.resolve_pins(si, {pins: [{a: 1}]}))
-           .to.equal(['a:1'])
-
-
-    expect(intern.resolve_pins(si, {pin: 'a:1,b:2'}))
-           .to.equal(['a:1,b:2'])
-
-    expect(intern.resolve_pins(si, {pin: 'b:2,a:1'}))
-           .to.equal(['a:1,b:2'])
-
-    expect(intern.resolve_pins(si, {pin: 'a:1;b:2'}))
-           .to.equal(['a:1', 'b:2'])
-
-    expect(intern.resolve_pins(si, {pin: 'b:2;a:1'}))
-           .to.equal(['b:2', 'a:1'])
-
-    expect(intern.resolve_pins(si, {pin: 'a:1;a:1'}))
-           .to.equal(['a:1', 'a:1'])
-
-
-    expect(intern.resolve_pins(si, {pins: 'a:1;b:2'}))
-           .to.equal(['a:1', 'b:2'])
-
-    expect(intern.resolve_pins(si, {pins: ['a:1;b:2']}))
-           .to.equal(['a:1', 'b:2'])
-
-    expect(intern.resolve_pins(si, {pins: [{a: 1}, {b: 2}]}))
-           .to.equal(['a:1', 'b:2'])
-
-    expect(intern.resolve_pins(si, {pins: ['a:1', 'b:2']}))
-           .to.equal(['a:1', 'b:2'])
-
-    expect(intern.resolve_pins(si, {pin: 'a:1,b:2;c:3'}))
-           .to.equal(['a:1,b:2', 'c:3'])
-
-    expect(intern.resolve_pins(si, {pin: 'c:3;a:1,b:2'}))
-           .to.equal(['c:3', 'a:1,b:2'])
-
-
-    done()
-  })
-
-
-  it('base', {timeout: 5555, parallel: false}, function (done) {
-    Seneca({tag: 'b0a', log: 'test', debug: {short_logs: true}})
-    .error(done)
-    .use('..', {isbase: true, discover: test_discover})
-    .ready(function () {
-      this.close(setTimeout.bind(this, done, 555))
+    ).to.equal({
+      id: 'pin:a:1,x:1~i0',
+      pin: 'a:1',
+      x: 1
     })
+
+    expect(
+      intern.make_pin_config(si, { identifier$: 'i0' }, 'a:1', {
+        pins: [{ a: 1 }, 'b:1'],
+        x: 1
+      })
+    ).to.equal({
+      id: 'pin:a:1,x:1~i0',
+      pin: 'a:1',
+      x: 1
+    })
+
+    done()
   })
 
+  it('intern.resolve_pins', function(done) {
+    var si = Seneca({ log: 'silent' })
 
-  it('single-with-base', {parallel: false, timeout: 5555}, function (done) {
+    expect(intern.resolve_pins(si, { pin: 'a:1' })).to.equal(['a:1'])
+
+    expect(intern.resolve_pins(si, { pin: { a: 1 } })).to.equal(['a:1'])
+
+    expect(intern.resolve_pins(si, { pins: 'a:1' })).to.equal(['a:1'])
+
+    expect(intern.resolve_pins(si, { pins: { a: 1 } })).to.equal(['a:1'])
+
+    expect(intern.resolve_pins(si, { pin: ['a:1'] })).to.equal(['a:1'])
+
+    expect(intern.resolve_pins(si, { pin: [{ a: 1 }] })).to.equal(['a:1'])
+
+    expect(intern.resolve_pins(si, { pins: ['a:1'] })).to.equal(['a:1'])
+
+    expect(intern.resolve_pins(si, { pins: [{ a: 1 }] })).to.equal(['a:1'])
+
+    expect(intern.resolve_pins(si, { pin: 'a:1,b:2' })).to.equal(['a:1,b:2'])
+
+    expect(intern.resolve_pins(si, { pin: 'b:2,a:1' })).to.equal(['a:1,b:2'])
+
+    expect(intern.resolve_pins(si, { pin: 'a:1;b:2' })).to.equal(['a:1', 'b:2'])
+
+    expect(intern.resolve_pins(si, { pin: 'b:2;a:1' })).to.equal(['b:2', 'a:1'])
+
+    expect(intern.resolve_pins(si, { pin: 'a:1;a:1' })).to.equal(['a:1', 'a:1'])
+
+    expect(intern.resolve_pins(si, { pins: 'a:1;b:2' })).to.equal([
+      'a:1',
+      'b:2'
+    ])
+
+    expect(intern.resolve_pins(si, { pins: ['a:1;b:2'] })).to.equal([
+      'a:1',
+      'b:2'
+    ])
+
+    expect(intern.resolve_pins(si, { pins: [{ a: 1 }, { b: 2 }] })).to.equal([
+      'a:1',
+      'b:2'
+    ])
+
+    expect(intern.resolve_pins(si, { pins: ['a:1', 'b:2'] })).to.equal([
+      'a:1',
+      'b:2'
+    ])
+
+    expect(intern.resolve_pins(si, { pin: 'a:1,b:2;c:3' })).to.equal([
+      'a:1,b:2',
+      'c:3'
+    ])
+
+    expect(intern.resolve_pins(si, { pin: 'c:3;a:1,b:2' })).to.equal([
+      'c:3',
+      'a:1,b:2'
+    ])
+
+    done()
+  })
+
+  it('base', { timeout: 5555, parallel: false }, function(done) {
+    Seneca({ tag: 'b0a', log: 'test', debug: { short_logs: true } })
+      .error(done)
+      .use('..', { isbase: true, discover: test_discover })
+      .ready(function() {
+        this.close(setTimeout.bind(this, done, 555))
+      })
+  })
+
+  it('single-with-base', { parallel: false, timeout: 5555 }, function(done) {
     var b0b, s0b
 
-    b0b =
-      Seneca({tag: 'b0b', log: 'silent', debug: {short_logs: true}})
+    b0b = Seneca({ tag: 'b0b', log: 'silent', debug: { short_logs: true } })
       .error(done)
-      .use('..', {isbase: true, discover: test_discover})
+      .use('..', { isbase: true, discover: test_discover })
 
-    s0b =
-      Seneca({tag: 's0b', log: 'silent', debug: {short_logs: true}})
+    s0b = Seneca({ tag: 's0b', log: 'silent', debug: { short_logs: true } })
       .error(done)
-      .add('a:1', function (msg) { this.good({x: msg.i}) })
+      .add('a:1', function(msg) {
+        this.good({ x: msg.i })
+      })
 
-    b0b.ready(function () {
-      s0b.use('..', {pin: 'a:1', discover: test_discover}).ready(function () {
-        s0b.act('role:mesh,get:members', function (err, out) {
-          if (err) { done(err) }
+    b0b.ready(function() {
+      s0b.use('..', { pin: 'a:1', discover: test_discover }).ready(function() {
+        s0b.act('role:mesh,get:members', function(err, out) {
+          if (err) {
+            done(err)
+          }
           Assert.equal(1, out.list.length)
 
-          b0b.act('a:1,i:0', function (err, out) {
-            if (err) { done(err) }
+          b0b.act('a:1,i:0', function(err, out) {
+            if (err) {
+              done(err)
+            }
             Assert.equal(0, out.x)
 
-            b0b.act('a:1,i:1', function (err, out) {
-              if (err) { done(err) }
+            b0b.act('a:1,i:1', function(err, out) {
+              if (err) {
+                done(err)
+              }
               Assert.equal(1, out.x)
 
               s0b.close(b0b.close.bind(b0b, setTimeout.bind(this, done, 555)))
@@ -230,229 +240,330 @@ describe('#mesh', function () {
     })
   })
 
-  it('happy', {parallel: false, timeout: 5555}, function (fin) {
+  it('happy', { parallel: false, timeout: 5555 }, function(fin) {
     var b0, s0, s1, c0
 
-    b0 =
-      Seneca({id$: 'b0'})
+    b0 = Seneca({ id$: 'b0' })
       .test(fin)
-      .use('..', {base: true, discover: test_discover, sneeze: {silent: true}})
+      .use('..', {
+        base: true,
+        discover: test_discover,
+        sneeze: { silent: true }
+      })
 
-    s0 =
-      Seneca({id$: 's0'})
+    s0 = Seneca({ id$: 's0' })
       .test(fin)
-      .use('..', {pin: 'a:1', discover: test_discover, sneeze: {silent: true}})
-      .add('a:1', function (m, r) { r({x: 0}) })
+      .use('..', {
+        pin: 'a:1',
+        discover: test_discover,
+        sneeze: { silent: true }
+      })
+      .add('a:1', function(m, r) {
+        r({ x: 0 })
+      })
 
-    s1 =
-      Seneca({id$: 's1'})
-      .test(fin)//, 'print')
-      .use('..', {pin: 'a:1', discover: test_discover, sneeze: {silent: true}})
-      .add('a:1', function (m, r) { r({x: 1}) })
-      .add('a:1', function (m, r) {
+    s1 = Seneca({ id$: 's1' })
+      .test(fin) //, 'print')
+      .use('..', {
+        pin: 'a:1',
+        discover: test_discover,
+        sneeze: { silent: true }
+      })
+      .add('a:1', function(m, r) {
+        r({ x: 1 })
+      })
+      .add('a:1', function(m, r) {
         this.prior(m, r)
       })
 
-    c0 =
-      Seneca({id$: 'c0'})
+    c0 = Seneca({ id$: 'c0' })
       .test(fin)
-      .use('..', {discover: test_discover, sneeze: {silent: true}})
+      .use('..', { discover: test_discover, sneeze: { silent: true } })
 
-    b0.ready(s0.ready.bind(s0, s1.ready.bind(s1, c0.ready.bind(c0, function () {
-      c0
-        .gate()
-        .act({role: 'transport', type: 'balance', get: 'target-map'},
-             function(e,o){
-               expect(o['a:1']['a:1'].targets.length).equal(2)
-             })
-      
-        .act({role: 'mesh', get: 'members'},
-             function(e,o){
-               expect(o.list.length).equal(3)
-             })
+    b0.ready(
+      s0.ready.bind(
+        s0,
+        s1.ready.bind(
+          s1,
+          c0.ready.bind(c0, function() {
+            c0
+              .gate()
+              .act(
+                { role: 'transport', type: 'balance', get: 'target-map' },
+                function(e, o) {
+                  expect(o['a:1']['a:1'].targets.length).equal(2)
+                }
+              )
+              .act({ role: 'mesh', get: 'members' }, function(e, o) {
+                expect(o.list.length).equal(3)
+              })
+              .act('a:1,s:0', function(e, o) {
+                expect(o.x).equal(0)
+              })
+              .act('a:1,s:1', function(e, o) {
+                expect(o.x).equal(1)
+              })
+              .act('a:1,s:2', function(e, o) {
+                expect(o.x).equal(0)
+              })
+              .ready(function() {
+                b0.act('role:mesh,get:members', function(e, o) {
+                  expect(o.list.length).equal(3)
 
-        .act('a:1,s:0', function (e, o) {
-          expect(o.x).equal(0)
-        })
-        .act('a:1,s:1', function (e, o) {
-          expect(o.x).equal(1)
-        })
-        .act('a:1,s:2', function (e, o) {
-          expect(o.x).equal(0)
-        })
-
-        .ready(function() {
-          b0.act('role:mesh,get:members', function (e, o) {
-            expect(o.list.length).equal(3)
-
-            s0.close(setTimeout.bind(null,function () {
-              c0
-                .act('a:1,s:3', function (e, o) {
-                  expect(o.x).equal(1)
+                  s0.close(
+                    setTimeout.bind(
+                      null,
+                      function() {
+                        c0
+                          .act('a:1,s:3', function(e, o) {
+                            expect(o.x).equal(1)
+                          })
+                          .act('a:1,s:4', function(e, o) {
+                            expect(o.x).equal(1)
+                          })
+                          .close(s1.close.bind(s1, b0.close.bind(b0, fin)))
+                      },
+                      1555
+                    )
+                  )
                 })
-                .act('a:1,s:4', function (e, o) {
-                  expect(o.x).equal(1)
-                })
-              
-                .close(s1.close.bind(s1,b0.close.bind(b0, fin)))},1555))
+              })
           })
-        })
-    }))))
+        )
+      )
+    )
   })
 
-
-  it('many-actors', {parallel: false, timeout: 19999}, function (done) {
+  it('many-actors', { parallel: false, timeout: 19999 }, function(done) {
     var b0, s0, s1, s2, c0, c1
 
-    b0 = Seneca({tag: 'b0', log: 'test', debug: {short_logs: true}})
+    b0 = Seneca({ tag: 'b0', log: 'test', debug: { short_logs: true } }).error(
+      done
+    )
+
+    s0 = Seneca({ tag: 's0', log: 'test', debug: { short_logs: true } })
       .error(done)
+      .add('a:1', function(m) {
+        this.good({ x: m.x + 1 })
+      })
 
-    s0 = Seneca({tag: 's0', log: 'test', debug: {short_logs: true}})
+    s1 = Seneca({ tag: 's1', log: 'test', debug: { short_logs: true } })
       .error(done)
-      .add('a:1', function (m) { this.good({x: m.x + 1}) })
+      .add('a:1', function(m) {
+        this.good({ x: m.x + 2 })
+      })
 
-    s1 = Seneca({tag: 's1', log: 'test', debug: {short_logs: true}})
+    s2 = Seneca({ tag: 's2', log: 'test', debug: { short_logs: true } })
       .error(done)
-      .add('a:1', function (m) { this.good({x: m.x + 2}) })
+      .add('a:1', function(m) {
+        this.good({ x: m.x + 3 })
+      })
 
-    s2 = Seneca({tag: 's2', log: 'test', debug: {short_logs: true}})
-      .error(done)
-      .add('a:1', function (m) { this.good({x: m.x + 3}) })
+    c0 = Seneca({ tag: 'c0', log: 'test', debug: { short_logs: true } }).error(
+      done
+    )
 
-    c0 = Seneca({tag: 'c0', log: 'test', debug: {short_logs: true}})
-      .error(done)
+    c1 = Seneca({ tag: 'c1', log: 'test', debug: { short_logs: true } }).error(
+      done
+    )
 
-    c1 = Seneca({tag: 'c1', log: 'test', debug: {short_logs: true}})
-      .error(done)
+    b0
+      .use('..', {
+        isbase: true,
+        discover: test_discover,
+        sneeze: { silent: true }
+      })
+      .ready(function() {
+        s0
+          .use('..', {
+            pin: 'a:1',
+            model: 'actor',
+            discover: test_discover,
+            sneeze: { silent: true }
+          })
+          .ready(function() {
+            s1
+              .use('..', {
+                pin: 'a:1',
+                model: 'actor',
+                discover: test_discover,
+                sneeze: { silent: true }
+              })
+              .ready(function() {
+                s2
+                  .use('..', {
+                    pin: 'a:1',
+                    model: 'actor',
+                    discover: test_discover,
+                    sneeze: { silent: true }
+                  })
+                  .ready(function() {
+                    c0
+                      .use('..', {
+                        discover: test_discover,
+                        sneeze: { silent: true }
+                      })
+                      .ready(function() {
+                        c1
+                          .use('..', {
+                            discover: test_discover,
+                            sneeze: { silent: true }
+                          })
+                          .ready(setTimeout.bind(null, do_topology, 1222))
+                      })
+                  })
+              })
+          })
+      })
 
-
-    b0.use('..', {isbase: true, discover: test_discover, sneeze: {silent: true}}).ready(function () {
-      s0.use('..', {pin: 'a:1', model: 'actor', discover: test_discover, sneeze: {silent: true}}).ready(function () {
-        s1.use('..', {pin: 'a:1', model: 'actor', discover: test_discover, sneeze: {silent: true}}).ready(function () {
-          s2.use('..', {pin: 'a:1', model: 'actor', discover: test_discover, sneeze: {silent: true}}).ready(function () {
-            c0.use('..', {discover: test_discover, sneeze: {silent: true}}).ready(function () {
-              c1.use('..', {discover: test_discover, sneeze: {silent: true}}).ready(setTimeout.bind(null, do_topology, 1222))
-            }) }) }) }) })
-
-    function do_topology () {
-      c0.act('role:mesh,get:members', function (err, o) {
-        if (err) { done(err) }
+    function do_topology() {
+      c0.act('role:mesh,get:members', function(err, o) {
+        if (err) {
+          done(err)
+        }
         Assert.equal(5, o.list.length)
 
-        c1.act('role:mesh,get:members', function (err, o) {
-          if (err) { done(err) }
+        c1.act('role:mesh,get:members', function(err, o) {
+          if (err) {
+            done(err)
+          }
           Assert.equal(5, o.list.length)
 
-          c0.act('role:transport,type:balance,get:target-map,pg:"a:1"', function (err, c0map) {
-            if (err) { done(err) }
-            Assert.equal(3, c0map['a:1'].targets.length)
+          c0.act(
+            'role:transport,type:balance,get:target-map,pg:"a:1"',
+            function(err, c0map) {
+              if (err) {
+                done(err)
+              }
+              Assert.equal(3, c0map['a:1'].targets.length)
 
-            c1.act('role:transport,type:balance,get:target-map,pg:"a:1"', function (err, c1map) {
-              if (err) { done(err) }
-              Assert.equal(3, c1map['a:1'].targets.length)
+              c1.act(
+                'role:transport,type:balance,get:target-map,pg:"a:1"',
+                function(err, c1map) {
+                  if (err) {
+                    done(err)
+                  }
+                  Assert.equal(3, c1map['a:1'].targets.length)
 
-              do_actors(c0map, c1map)
+                  do_actors(c0map, c1map)
+                }
+              )
+            }
+          )
+        })
+      })
+    }
+
+    function do_actors(c0map, c1map) {
+      // var i = 0
+      // console.log(i++,'c0',c0map['a:1'].index,c0map.x,'c1',c1map['a:1'].index,c1map.x)
+
+      c0.act('a:1,x:0', function(e, o) {
+        // console.log(i++,'c0',c0map['a:1'].index,'c1',c1map['a:1'].index)
+        Assert.equal(1, o.x)
+
+        c1.act('a:1,x:0', function(e, o) {
+          // console.log(i++,'c0',c0map['a:1'].index,'c1',c1map['a:1'].index)
+          Assert.equal(1, o.x)
+
+          c0.act('a:1,x:0', function(e, o) {
+            Assert.equal(2, o.x)
+
+            c1.act('a:1,x:0', function(e, o) {
+              Assert.equal(2, o.x)
+
+              c0.act('a:1,x:0', function(e, o) {
+                Assert.equal(3, o.x)
+
+                c1.act('a:1,x:0', function(e, o) {
+                  Assert.equal(3, o.x)
+
+                  c0.act('a:1,x:0', function(e, o) {
+                    Assert.equal(1, o.x)
+
+                    c1.act('a:1,x:0', function(e, o) {
+                      Assert.equal(1, o.x)
+
+                      c0.act('a:1,x:0', function(e, o) {
+                        Assert.equal(2, o.x)
+
+                        c1.act('a:1,x:0', function(e, o) {
+                          Assert.equal(2, o.x)
+
+                          c0.act('a:1,x:0', function(e, o) {
+                            Assert.equal(3, o.x)
+
+                            c1.act('a:1,x:0', function(e, o) {
+                              Assert.equal(3, o.x)
+
+                              s1.close(setTimeout.bind(this, do_s1_down, 2555))
+                            })
+                          })
+                        })
+                      })
+                    })
+                  })
+                })
+              })
             })
           })
         })
       })
     }
 
-    function do_actors (c0map, c1map) {
-      // var i = 0
-      // console.log(i++,'c0',c0map['a:1'].index,c0map.x,'c1',c1map['a:1'].index,c1map.x)
-
-      c0.act('a:1,x:0', function (e, o) {
-        // console.log(i++,'c0',c0map['a:1'].index,'c1',c1map['a:1'].index)
+    function do_s1_down() {
+      c0.act('a:1,x:0', function(e, o) {
         Assert.equal(1, o.x)
 
-        c1.act('a:1,x:0', function (e, o) {
-          // console.log(i++,'c0',c0map['a:1'].index,'c1',c1map['a:1'].index)
+        c1.act('a:1,x:0', function(e, o) {
           Assert.equal(1, o.x)
 
-          c0.act('a:1,x:0', function (e, o) {
-            Assert.equal(2, o.x)
-
-            c1.act('a:1,x:0', function (e, o) {
-              Assert.equal(2, o.x)
-
-              c0.act('a:1,x:0', function (e, o) {
-                Assert.equal(3, o.x)
-
-                c1.act('a:1,x:0', function (e, o) {
-                  Assert.equal(3, o.x)
-
-                  c0.act('a:1,x:0', function (e, o) {
-                    Assert.equal(1, o.x)
-
-                    c1.act('a:1,x:0', function (e, o) {
-                      Assert.equal(1, o.x)
-
-                      c0.act('a:1,x:0', function (e, o) {
-                        Assert.equal(2, o.x)
-
-                        c1.act('a:1,x:0', function (e, o) {
-                          Assert.equal(2, o.x)
-
-                          c0.act('a:1,x:0', function (e, o) {
-                            Assert.equal(3, o.x)
-
-                            c1.act('a:1,x:0', function (e, o) {
-                              Assert.equal(3, o.x)
-
-                              s1.close(setTimeout.bind(this, do_s1_down, 2555))
-                            }) }) })
-                      }) }) })
-                }) }) })
-          }) }) })
-    }
-
-    function do_s1_down () {
-      c0.act('a:1,x:0', function (e, o) {
-        Assert.equal(1, o.x)
-
-        c1.act('a:1,x:0', function (e, o) {
-          Assert.equal(1, o.x)
-
-          c0.act('a:1,x:0', function (e, o) {
+          c0.act('a:1,x:0', function(e, o) {
             Assert.equal(3, o.x)
 
-            c1.act('a:1,x:0', function (e, o) {
+            c1.act('a:1,x:0', function(e, o) {
               Assert.equal(3, o.x)
 
-              c0.act('a:1,x:0', function (e, o) {
+              c0.act('a:1,x:0', function(e, o) {
                 Assert.equal(1, o.x)
 
-                c1.act('a:1,x:0', function (e, o) {
+                c1.act('a:1,x:0', function(e, o) {
                   Assert.equal(1, o.x)
 
-                  c0.act('a:1,x:0', function (e, o) {
+                  c0.act('a:1,x:0', function(e, o) {
                     Assert.equal(3, o.x)
 
-                    c1.act('a:1,x:0', function (e, o) {
+                    c1.act('a:1,x:0', function(e, o) {
                       Assert.equal(3, o.x)
 
-                      c0.act('a:1,x:0', function (e, o) {
+                      c0.act('a:1,x:0', function(e, o) {
                         Assert.equal(1, o.x)
 
-                        c1.act('a:1,x:0', function (e, o) {
+                        c1.act('a:1,x:0', function(e, o) {
                           Assert.equal(1, o.x)
 
-                          c0.act('a:1,x:0', function (e, o) {
+                          c0.act('a:1,x:0', function(e, o) {
                             Assert.equal(3, o.x)
 
-                            c1.act('a:1,x:0', function (e, o) {
+                            c1.act('a:1,x:0', function(e, o) {
                               Assert.equal(3, o.x)
 
                               close()
-                            }) }) })
-                      }) }) })
-                }) }) })
-          }) }) })
+                            })
+                          })
+                        })
+                      })
+                    })
+                  })
+                })
+              })
+            })
+          })
+        })
+      })
     }
 
-
-    function close () {
+    function close() {
       c1.close()
       c0.close()
       s2.close()
@@ -462,53 +573,73 @@ describe('#mesh', function () {
     }
   })
 
-
-  it('observe-consume-basic', {parallel: false, timeout: 9999}, function (done) {
+  it('observe-consume-basic', { parallel: false, timeout: 9999 }, function(
+    done
+  ) {
     var b0, s0, s1, c0
     var s0x = 0
     var s1z = 0
     var s0y = []
     var s1y = []
 
-    b0 = Seneca({tag: 'b0', log: 'test'})
+    b0 = Seneca({ tag: 'b0', log: 'test' }).error(done)
+
+    s0 = Seneca({ tag: 's0', log: 'test' })
       .error(done)
+      .add('a:1', function(m) {
+        this.good({ x: m.x + ++s0x })
+      })
+      .add('b:1', function(m) {
+        s0y.push(m.y)
+        this.good()
+      })
 
-    s0 = Seneca({tag: 's0', log: 'test'})
+    s1 = Seneca({ tag: 's1', log: 'test' })
       .error(done)
-      .add('a:1', function (m) { this.good({x: m.x + (++s0x)}) })
-      .add('b:1', function (m) { s0y.push(m.y); this.good() })
+      .add('b:1', function(m) {
+        s1y.push(m.y)
+        this.good()
+      })
+      .add('c:1', function(m) {
+        this.good({ z: m.z + ++s1z })
+      })
 
-    s1 = Seneca({tag: 's1', log: 'test'})
-      .error(done)
-      .add('b:1', function (m) { s1y.push(m.y); this.good() })
-      .add('c:1', function (m) { this.good({z: m.z + (++s1z)}) })
+    c0 = Seneca({ tag: 'c0', log: 'test' }).error(done)
 
-    c0 = Seneca({tag: 'c0', log: 'test'})
-      .error(done)
+    b0
+      .use('..', {
+        isbase: true,
+        discover: test_discover,
+        sneeze: { silent: true }
+      })
+      .ready(function() {
+        s0
+          .use('..', {
+            listen: [{ pin: 'a:1' }, { pin: 'b:1', model: 'observe' }],
+            discover: test_discover
+          })
+          .ready(function() {
+            s1
+              .use('..', {
+                listen: [{ pin: 'c:1' }, { pin: 'b:1', model: 'observe' }],
+                discover: test_discover
+              })
+              .ready(function() {
+                c0
+                  .use('..', {
+                    discover: test_discover,
+                    sneeze: { silent: true }
+                  })
+                  .ready(do_abc)
+              })
+          })
+      })
 
-
-    b0.use('..', {isbase: true, discover: test_discover, sneeze: {silent: true}}).ready(function () {
-      s0.use('..', {
-        listen: [
-          {pin: 'a:1'},
-          {pin: 'b:1', model: 'observe'}
-        ], discover: test_discover
-      }).ready(function () {
-        s1.use('..', {
-          listen: [
-              {pin: 'c:1'},
-              {pin: 'b:1', model: 'observe'}
-          ], discover: test_discover
-        }).ready(function () {
-          c0.use('..', {discover: test_discover, sneeze: {silent: true}}).ready(do_abc)
-        }) }) })
-
-
-    function do_abc () {
-      c0.act('a:1,x:0', function (e, o) {
+    function do_abc() {
+      c0.act('a:1,x:0', function(e, o) {
         Assert.equal(1, o.x)
 
-        c0.act('a:1,x:0', function (e, o) {
+        c0.act('a:1,x:0', function(e, o) {
           Assert.equal(2, o.x)
 
           c0.act('b:1,y:0')
@@ -516,24 +647,25 @@ describe('#mesh', function () {
           c0.act('b:1,y:2')
           c0.act('b:1,y:3')
 
-          setTimeout(function () {
+          setTimeout(function() {
             Assert.deepEqual([0, 1, 2, 3], s0y)
             Assert.deepEqual([0, 1, 2, 3], s1y)
 
-            c0.act('c:1,z:0', function (e, o) {
+            c0.act('c:1,z:0', function(e, o) {
               Assert.equal(1, o.z)
 
-              c0.act('c:1,z:0', function (e, o) {
+              c0.act('c:1,z:0', function(e, o) {
                 Assert.equal(2, o.z)
 
                 close()
-              }) })
+              })
+            })
           }, 111)
-        }) })
+        })
+      })
     }
 
-
-    function close () {
+    function close() {
       c0.close()
       s1.close()
       s0.close()
@@ -542,16 +674,14 @@ describe('#mesh', function () {
     }
   })
 
-
-  it('single-custom', {parallel: false, timeout: 5555}, function (done) {
+  it('single-custom', { parallel: false, timeout: 5555 }, function(done) {
     var b0b, s0b
 
-    function custom_bases (seneca, options, bases, next) {
+    function custom_bases(seneca, options, bases, next) {
       next(['127.0.0.1:39901'])
     }
 
-    b0b =
-      Seneca({tag: 'b0b', log: 'silent', debug: {short_logs: true}})
+    b0b = Seneca({ tag: 'b0b', log: 'silent', debug: { short_logs: true } })
       .error(done)
       .use('..', {
         isbase: true,
@@ -564,33 +694,43 @@ describe('#mesh', function () {
             active: true,
             find: custom_bases
           }
-        }})
+        }
+      })
 
-    s0b =
-      Seneca({tag: 's0b', log: 'silent', debug: {short_logs: true}})
+    s0b = Seneca({ tag: 's0b', log: 'silent', debug: { short_logs: true } })
       .error(done)
-      .add('a:1', function (msg) { this.good({x: msg.i}) })
+      .add('a:1', function(msg) {
+        this.good({ x: msg.i })
+      })
 
-    b0b.ready(function () {
-      s0b.use('..', {
-        pin: 'a:1',
-        discover: {
-          custom: {
-            active: true,
-            find: custom_bases
+    b0b.ready(function() {
+      s0b
+        .use('..', {
+          pin: 'a:1',
+          discover: {
+            custom: {
+              active: true,
+              find: custom_bases
+            }
           }
-        }})
-        .ready(function () {
-          s0b.act('role:mesh,get:members', function (err, out) {
-            if (err) { done(err) }
+        })
+        .ready(function() {
+          s0b.act('role:mesh,get:members', function(err, out) {
+            if (err) {
+              done(err)
+            }
             Assert.equal(1, out.list.length)
 
-            b0b.act('a:1,i:0', function (err, out) {
-              if (err) { done(err) }
+            b0b.act('a:1,i:0', function(err, out) {
+              if (err) {
+                done(err)
+              }
               Assert.equal(0, out.x)
 
-              b0b.act('a:1,i:1', function (err, out) {
-                if (err) { done(err) }
+              b0b.act('a:1,i:1', function(err, out) {
+                if (err) {
+                  done(err)
+                }
                 Assert.equal(1, out.x)
 
                 s0b.close()
@@ -603,49 +743,63 @@ describe('#mesh', function () {
     })
   })
 
-
   // Tests https://github.com/senecajs/seneca-mesh/issues/11
-  it('canonical-pins', {parallel: false, timeout: 5555}, function (done) {
-    var b0 = Seneca({legacy:{transport:false}}).test(done).use('..', {base: true})
-    var s0 = Seneca({legacy:{transport:false}}).test(done).use('..', {pin: 'a:1,b:2;c:3'})
-    var s1 = Seneca({legacy:{transport:false}}).test(done).use('..', {pin: 'c:3;b:2,a:1'})
-    var c0 = Seneca({legacy:{transport:false}}).test(done).use('..')
+  it('canonical-pins', { parallel: false, timeout: 5555 }, function(done) {
+    var b0 = Seneca({ legacy: { transport: false } })
+      .test(done)
+      .use('..', { base: true })
+    var s0 = Seneca({ legacy: { transport: false } })
+      .test(done)
+      .use('..', { pin: 'a:1,b:2;c:3' })
+    var s1 = Seneca({ legacy: { transport: false } })
+      .test(done)
+      .use('..', { pin: 'c:3;b:2,a:1' })
+    var c0 = Seneca({ legacy: { transport: false } })
+      .test(done)
+      .use('..')
 
-    s0.add('a:1,b:2', function (msg, reply) { reply({s: 0, x: msg.x}) })
-    s1.add('a:1,b:2', function (msg, reply) { reply({s: 1, x: msg.x}) })
+    s0.add('a:1,b:2', function(msg, reply) {
+      reply({ s: 0, x: msg.x })
+    })
+    s1.add('a:1,b:2', function(msg, reply) {
+      reply({ s: 1, x: msg.x })
+    })
 
-    s0.add('c:3', function (msg, reply) { reply({s: 0, y: msg.y}) })
-    s1.add('c:3', function (msg, reply) { reply({s: 1, y: msg.y}) })
+    s0.add('c:3', function(msg, reply) {
+      reply({ s: 0, y: msg.y })
+    })
+    s1.add('c:3', function(msg, reply) {
+      reply({ s: 1, y: msg.y })
+    })
 
-    setTimeout(function () {
+    setTimeout(function() {
       c0
         .gate()
-        .act('role:transport,type:balance,get:target-map', function (ignore, out) {
+        .act('role:transport,type:balance,get:target-map', function(
+          ignore,
+          out
+        ) {
           expect(out['a:1,b:2']['a:1,b:2'].targets.length).to.equal(2)
           expect(out['c:3']['c:3'].targets.length).to.equal(2)
           //console.dir(out,{depth:null})
         })
-
-        .act('c:3,y:100', function (ignore, out) {
-          expect(out).to.equal({s: 0, y: 100})
+        .act('c:3,y:100', function(ignore, out) {
+          expect(out).to.equal({ s: 0, y: 100 })
         })
-
-        .act('c:3,y:200', function (ignore, out) {
-          expect(out).to.equal({s: 1, y: 200})
+        .act('c:3,y:200', function(ignore, out) {
+          expect(out).to.equal({ s: 1, y: 200 })
         })
-        .act('c:3,y:300', function (ignore, out) {
-          expect(out).to.equal({s: 0, y: 300})
+        .act('c:3,y:300', function(ignore, out) {
+          expect(out).to.equal({ s: 0, y: 300 })
         })
-
-        .act('a:1,b:2,x:400', function (ignore, out) {
-          expect(out).to.equal({s: 0, x: 400})
+        .act('a:1,b:2,x:400', function(ignore, out) {
+          expect(out).to.equal({ s: 0, x: 400 })
         })
-        .act('a:1,b:2,x:500', function (ignore, out) {
-          expect(out).to.equal({s: 1, x: 500})
+        .act('a:1,b:2,x:500', function(ignore, out) {
+          expect(out).to.equal({ s: 1, x: 500 })
         })
-
-        .act('a:1,b:2,x:600', function (ignore, out) {
-          expect(out).to.equal({s: 0, x: 600})
+        .act('a:1,b:2,x:600', function(ignore, out) {
+          expect(out).to.equal({ s: 0, x: 600 })
 
           c0.close()
           s0.close()
@@ -658,33 +812,42 @@ describe('#mesh', function () {
   })
 })
 
-
-function make_rif () {
+function make_rif() {
   var netif = {
-    lo:
-    [ { address: '127.0.0.1',
+    lo: [
+      {
+        address: '127.0.0.1',
         netmask: '255.0.0.0',
         family: 'IPv4',
         mac: '00:00:00:00:00:00',
-        internal: true },
-      { address: '::1',
+        internal: true
+      },
+      {
+        address: '::1',
         netmask: 'ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff',
         family: 'IPv6',
         mac: '00:00:00:00:00:00',
         scopeid: 0,
-        internal: true } ],
-    eth0:
-    [ { address: '10.0.2.15',
+        internal: true
+      }
+    ],
+    eth0: [
+      {
+        address: '10.0.2.15',
         netmask: '255.255.255.0',
         family: 'IPv4',
         mac: '08:00:27:1b:bc:e9',
-        internal: false },
-      { address: 'fe80::a00:27ff:fe1b:bce9',
+        internal: false
+      },
+      {
+        address: 'fe80::a00:27ff:fe1b:bce9',
         netmask: 'ffff:ffff:ffff:ffff::',
         family: 'IPv6',
         mac: '08:00:27:1b:bc:e9',
         scopeid: 2,
-        internal: false } ]
+        internal: false
+      }
+    ]
   }
 
   return Rif(netif)


### PR DESCRIPTION
This adds the capability to let the node rediscover the bases, when it lost all entries of all bases available.

Currenlty this node silently fails without noticing and ends up as a dangling node in the network, which suddenly can't communicate with anyone else anymore.

Requires https://github.com/rjrodger/sneeze/pull/17